### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 UIImage+ImageCompress is a UIImage category that compress a local or
 remote UIImage 
 
-#Install
+# Install
 
 Install with [cocoapods](http://cocoapods.org/)
 
@@ -9,7 +9,7 @@ Install with [cocoapods](http://cocoapods.org/)
 pod 'UIImage+ImageCompress'
 ```
 
-#Usage
+# Usage
 
 ```
     UIImage *imageToCompress = [UIImage imageNamed:@"theJoker.jpg"];


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
